### PR TITLE
[CHK-3223] feat: add mocked case for already paid notice (`PAA_PAGAMENTO_DUPLICATO`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,14 +238,16 @@ The tribute is 120.00 EUR divided in 2 transfers:
 
 The following edge cases are available (stateless, based on notice number)
 
-| Notice number        | Description            |
-| -------------------- | ---------------------- |
-| 302**97**xxxxxxxxxxx | Station not reacheable |
-| 302**98**xxxxxxxxxxx | Station timeout        |
-| 302**99**xxxxxxxxxxx | Payment expired        |
-| 302**YY**xxxxxxxxxxx | Payment unknown        |
+| Notice number        | Description                                          |
+| -------------------- | ---------------------------------------------------- |
+| 302**95**xxxxxxxxxxx | Notice already paid                                  |
+| 302**96**xxxxxxxxxxx | EC is returning a response with a syntax error       |
+| 302**97**xxxxxxxxxxx | EC Station not reacheable                            |
+| 302**98**xxxxxxxxxxx | EC Station timeout                                   |
+| 302**99**xxxxxxxxxxx | Payment expired                                      |
+| 302**YY**xxxxxxxxxxx | Payment unknown                                      |
 
-**_NOTE:_** YY: every code not mentioned before -> from 17 to 96
+**_NOTE:_** YY: every code not mentioned before -> from 17 to 94
 
 <br>
 <!-- 

--- a/src/app.ts
+++ b/src/app.ts
@@ -98,7 +98,7 @@ const avvisoOver5000 = new RegExp('^30277.*'); // random over 5000 euro + random
 const avvisoUnder1 = new RegExp('^30288.*'); // random under 1 euro + + random su 2 transfers
 
 // Special error cases
-const avvisoPagamentoDuplicato = new RegExp('^30295.*'); // fix response
+const avvisoPagamentoDuplicato = new RegExp('^30295.*'); // PAA_PAGAMENTO_DUPLICATO
 const avvisoErroreXSD = new RegExp('^30296.*'); // PAA_SINTASSI_XSD
 const avvisoErrore = new RegExp('^30297.*'); // paErrorVerify
 const avvisoTimeout = new RegExp('^30298.*'); // timeout
@@ -537,9 +537,7 @@ export async function newExpressApp(
           });
           return res.status(paActivate24res[0]).send(paActivate24res[1]);
         } else if (avvisoPagamentoDuplicato.test(noticenumber)) {
-          const paActivateDuplicatoRes = paActivatePagamentoDuplicato({
-            creditorReferenceId,
-          });
+          const paActivateDuplicatoRes = paActivatePagamentoDuplicato();
           return res.status(paActivateDuplicatoRes[0]).send(paActivateDuplicatoRes[1]);
         }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -38,6 +38,7 @@ import {
   paVerify22,
   paVerify23,
   paVerify24,
+  paVerifyPagamentoDuplicato,
 } from './fixtures/fixVerifyResponse';
 import {
   paActivate17,
@@ -48,6 +49,7 @@ import {
   paActivate22,
   paActivate23,
   paActivate24,
+  paActivatePagamentoDuplicato,
 } from './fixtures/fixActivateResponse';
 
 const paVerifyPaymentNoticeQueue = new Array<string>();
@@ -95,12 +97,12 @@ const avviso25 = new RegExp('^30224.*'); // fix response
 const avvisoOver5000 = new RegExp('^30277.*'); // random over 5000 euro + random su 2 transfers
 const avvisoUnder1 = new RegExp('^30288.*'); // random under 1 euro + + random su 2 transfers
 
-const avvisoScaduto = new RegExp('^30299.*'); // PAA_PAGAMENTO_SCADUTO
-
-const avvisoTimeout = new RegExp('^30298.*'); // timeout
-const avvisoErrore = new RegExp('^30297.*'); // paErrorVerify
-
+// Special error cases
+const avvisoPagamentoDuplicato = new RegExp('^30295.*'); // fix response
 const avvisoErroreXSD = new RegExp('^30296.*'); // PAA_SINTASSI_XSD
+const avvisoErrore = new RegExp('^30297.*'); // paErrorVerify
+const avvisoTimeout = new RegExp('^30298.*'); // timeout
+const avvisoScaduto = new RegExp('^30299.*'); // PAA_PAGAMENTO_SCADUTO
 
 const amount1 = 100.0;
 const amount1bis = 70.0;
@@ -276,6 +278,8 @@ export async function newExpressApp(
           return res.status(200).send(paVerify23);
         } else if (avviso25.test(noticenumber)) {
           return res.status(200).send(paVerify24);
+        } else if (avvisoPagamentoDuplicato.test(noticenumber)) {
+          return res.status(200).send(paVerifyPagamentoDuplicato);
         }
 
         if (testDebug.toUpperCase() === 'Y') {
@@ -532,6 +536,11 @@ export async function newExpressApp(
             creditorReferenceId,
           });
           return res.status(paActivate24res[0]).send(paActivate24res[1]);
+        } else if (avvisoPagamentoDuplicato.test(noticenumber)) {
+          const paActivateDuplicatoRes = paActivatePagamentoDuplicato({
+            creditorReferenceId,
+          });
+          return res.status(paActivateDuplicatoRes[0]).send(paActivateDuplicatoRes[1]);
         }
 
         const isFixedError = avvisoErrore.test(noticenumber);

--- a/src/fixtures/fixActivateResponse.ts
+++ b/src/fixtures/fixActivateResponse.ts
@@ -452,7 +452,7 @@ export const paActivate24 = (params: IActivateRequest): MockResponse => [
   </soapenv:Envelope>`,
 ];
 
-export const paActivatePagamentoDuplicato = (params: IActivateRequest): MockResponse => [
+export const paActivatePagamentoDuplicato = (): MockResponse => [
   200,
   `<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
     xmlns:paf="http://pagopa-api.pagopa.gov.it/pa/paForNode.xsd">

--- a/src/fixtures/fixActivateResponse.ts
+++ b/src/fixtures/fixActivateResponse.ts
@@ -451,3 +451,21 @@ export const paActivate24 = (params: IActivateRequest): MockResponse => [
   </soapenv:Body>
   </soapenv:Envelope>`,
 ];
+
+export const paActivatePagamentoDuplicato = (params: IActivateRequest): MockResponse => [
+  200,
+  `<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+    xmlns:paf="http://pagopa-api.pagopa.gov.it/pa/paForNode.xsd">
+    <soapenv:Header />
+    <soapenv:Body>
+        <paf:paGetPaymentRes>
+            <outcome>KO</outcome>
+            <fault>
+                <faultCode>PAA_PAGAMENTO_DUPLICATO</faultCode>
+                <faultString>Errore mockato - caso PAA_PAGAMENTO_DUPLICATO</faultString>
+                <id>77777777777</id>
+            </fault>
+        </paf:paGetPaymentRes>
+    </soapenv:Body>
+    </soapenv:Envelope>`,
+];

--- a/src/fixtures/fixVerifyResponse.ts
+++ b/src/fixtures/fixVerifyResponse.ts
@@ -181,3 +181,18 @@ export const paVerify24 = `<soapenv:Envelope xmlns:soapenv="http://schemas.xmlso
         </paf:paVerifyPaymentNoticeRes>
     </soapenv:Body>
 </soapenv:Envelope>`;
+
+export const paVerifyPagamentoDuplicato = `<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+    xmlns:paf="http://pagopa-api.pagopa.gov.it/pa/paForNode.xsd">
+    <soapenv:Header />
+    <soapenv:Body>
+        <paf:paVerifyPaymentNoticeRes>
+            <outcome>KO</outcome>
+            <fault>
+                <faultCode>PAA_PAGAMENTO_DUPLICATO</faultCode>
+                <faultString>Errore mockato - caso PAA_PAGAMENTO_DUPLICATO</faultString>
+                <id>77777777777</id>
+            </fault>
+        </paf:paVerifyPaymentNoticeRes>
+    </soapenv:Body>
+</soapenv:Envelope>`;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
 * add mock case for already paid notice (`PAA_PAGAMENTO_DUPLICATO`)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This PR adds an error case for both _verifyPaymentNoticeV2_ and _activatePaymentNotice_ endpoints for a payment notice that was already paid.
Differently from all other valid payment notices, this new range of payment notices (`30295xxxx...`) cannot be verified or activated successfully: an error of type `PAA_PAGAMENTO_DUPLICATO` with an outcome `KO` will be returned instead.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Deployed instance on UAT and check with Checkout

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.